### PR TITLE
(Refactor) refactors and organizes build.js code

### DIFF
--- a/build.js
+++ b/build.js
@@ -48,6 +48,7 @@ let completionsFile = JSON.parse(fs.readFileSync(files.sublimeCompletions, 'utf-
 
 console.log('Updating completions from data');
 
+completionsFile.completions = [];
 for (const [pattern, elements] of Object.entries(patterns)) {
 	Object.values(elements).forEach(({ name }, index) => {
 		const type = toCapital(pattern);
@@ -55,10 +56,10 @@ for (const [pattern, elements] of Object.entries(patterns)) {
 
 		if(pattern === 'natures') completion += ' Nature';
 
-		completionsFile.completions[index] = {
+		completionsFile.completions.push({
 			trigger: completion + '\t' + type,
 			contents: completion
-		};
+		});
 	})
 }
 

--- a/build.js
+++ b/build.js
@@ -7,9 +7,17 @@ import PokedexFile from "pokemon-showdown/.data-dist/pokedex.js";
 import NaturesFile from "pokemon-showdown/.data-dist/natures.js";
 
 console.log('-- Building Syntax Highlight File');
-let syntaxFile = fs.readFileSync('PokemonTeamSyntax.JSON-tmLanguage', 'utf-8');
+
+const files = {
+	JSONtmLanguage: 'PokemonTeamSyntax.JSON-tmLanguage',
+	tmLanguage: 'PokemonTeamSyntax.tmLanguage',
+	sublimeCompletions: 'PokemonTeamSyntax.sublime-completions',
+}
+
+let syntaxFile = fs.readFileSync(files.JSONtmLanguage, 'utf-8');
 
 console.log('Started fetching.');
+
 const patterns = {
 	abilities: AbilitiesFile.Abilities,
 	items: ItemsFile.Items,
@@ -18,39 +26,44 @@ const patterns = {
 	natures: NaturesFile.Natures
 };
 
+const toCapital = (str) => str[0].toUpperCase() + str.slice(1);
+
 for (const [pattern, elements] of Object.entries(patterns)) {
-	let list = [];
-	for (const element in elements) {
-		list.push(elements[element].name);
-	}
-	syntaxFile = syntaxFile.replace('{{' + pattern + '}}', list.sort().reverse().join('|'));
+	const list = Object.values(elements).map(x => x.name);
+	const replaceTarget = '{{' + pattern + '}}';
+	const replaceValue = list.sort().reverse().join('|');
+
+	syntaxFile = syntaxFile.replace(replaceTarget, replaceValue);
 }
 
 console.log('Data gathered, writing language file.');
-fs.writeFileSync('PokemonTeamSyntax.tmLanguage', plist.build(JSON.parse(syntaxFile)));
-console.log('Done.');
 
+fs.writeFileSync(files.tmLanguage, plist.build(JSON.parse(syntaxFile)));
+
+console.log('Done.');
 console.log('-- Building Completions File');
 console.log('Reading current Completions file');
-let completionsFile = JSON.parse(fs.readFileSync('PokemonTeamSyntax.sublime-completions', 'utf-8'));
+
+let completionsFile = JSON.parse(fs.readFileSync(files.sublimeCompletions, 'utf-8'));
 
 console.log('Updating completions from data');
-completionsFile.completions = [];
-let completion = '';
-let tip = '';
-for (const [pattern, elements] of Object.entries(patterns)) {
-	for (const element in elements) {
-		completion = elements[element].name;
-		completion = completion.charAt(0).toUpperCase() + completion.slice(1);
-		tip = pattern.charAt(0).toUpperCase() + pattern.slice(1);
 
-		completionsFile.completions.push({
-			trigger: completion + '\t' + tip,
-			contents: pattern !== 'natures' ? completion : completion + ' Nature'
-		});
-	}
+for (const [pattern, elements] of Object.entries(patterns)) {
+	Object.values(elements).forEach(({ name }, index) => {
+		const type = toCapital(pattern);
+		let completion = toCapital(name);
+
+		if(pattern === 'natures') completion += ' Nature';
+
+		completionsFile.completions[index] = {
+			trigger: completion + '\t' + type,
+			contents: completion
+		};
+	})
 }
 
 console.log('Update finished, writing completions file.');
-fs.writeFileSync('PokemonTeamSyntax.sublime-completions', JSON.stringify(completionsFile, null, '\t'));
+
+fs.writeFileSync(files.sublimeCompletions, JSON.stringify(completionsFile, null, '\t'));
+
 console.log('Done.');


### PR DESCRIPTION
## What was done:
- `L11` | Centralizes file names inside a variable, therefore if you change the name of a file, you would only need to change it in one place.
- `L29` | Creates a function toCapital, to follow DRY concept, since it was being used in line 44 and 35 before.
- `L32` | Instead of a for loop just to save the names of the list variable, it now runs Object.values and maps the values to only get the names, getting the same result as before.
- `L33/34` | Inserts replace target and value inside variables, for more readability at the replace function.
- ~`L39/40`~ | The variables completion and tip were being created outside and being overwritten by each loop. Since they weren't being used outside of the loop itself, they are created there now.
- `L51` | Before the `completionsFile.completions` array was being created as empty and then the values were pushed to it. Now it doesn't create it in advance, instead the loop just below creates the completions array using the index of the loop as a key, obtaining the same result as before.
- `L52` | Instead of running another for loop to get values, it runs Object.values.
- `L56` | The verification if the pattern was natures was being made in a ternary, but for keeping it easy to read, I transformed it into a if statement that adds to the completion variable, just as it was.
- Adds lines between console.logs